### PR TITLE
readme install instructions are wrong

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,5 +11,5 @@ Node's querystring module for all engines.
 
 ## Install ##
 
-    npm install querystring
+    npm install querystring-es3
 


### PR DESCRIPTION
published on npm as querystring-es3, not querystring