### PR TITLE
fix: do not return empty query for empty array

### DIFF
--- a/encode.js
+++ b/encode.js
@@ -54,7 +54,7 @@ module.exports = function(obj, sep, eq, name) {
       } else {
         return ks + encodeURIComponent(stringifyPrimitive(obj[k]));
       }
-    }).join(sep);
+    }).filter(function(q) {return q !== '';}).join(sep);
 
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -164,6 +164,9 @@ exports['test stringifying'] = function(assert) {
     assert.equal(testCase[1], qs.stringify(testCase[0]),
                  'stringify ' + JSON.stringify(testCase[0]));
   });
+
+  assert.equal(qs.stringify({filter:[], x:1}), 'x=1', 'stringify should not include empty array');
+  assert.equal(qs.stringify({filter:[]}), '', 'stringify should not include empty array');
 };
 
 exports['test stringifying nested'] = function(assert) {


### PR DESCRIPTION
```
# node v4.7.0
> require('querystring').stringify({filter: [], x: 1})
'x=1'
> require('querystring-es3').stringify({filter: [], x: 1})
'&x=1'
```

So the behavior is different with stock querystring module.

When using webpack 2, it seems that the `querystring-es3` polyfilled the `querystring`. Which may results `&&` in query when some query is empty array. Which will be parsed as `{'': ''}` in most web server implementation. And we are using Joi + Hapi.js as our server implementation. Which have 'allowUnkown => false' by default, the `&&` will cause 400 error. So I think this fix should help avoid this kind of issue.
